### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -4,6 +4,9 @@ on: [pull_request, issues]
 
 jobs:
   greeting:
+    permissions:
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/first-interaction@v3


### PR DESCRIPTION
Potential fix for [https://github.com/Stircrazy456/depndentbot/security/code-scanning/2](https://github.com/Stircrazy456/depndentbot/security/code-scanning/2)

The workflow should specify a `permissions` block with the least privileges necessary for its steps. The `actions/first-interaction` action needs to be able to read contents but, more importantly, it needs to write comments on issues and pull requests, so it specifically requires `issues: write` and `pull-requests: write` permissions. The best practice is to set these at the workflow or job level. Since this workflow appears to only use a single job, we can add the `permissions` block at the job level for clarity and to adhere to the recommendation. No functionality will change except for properly restricting the effective permissions of the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
